### PR TITLE
Feature/data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Description: Read and Parse for Fundamental Geo-Spatial Data (FGD) which downloa
     Supports the FGD version 4.1, and accepts fundamental items and digital elevation models.
 License: MIT + file LICENSE
 Imports: 
+    data.table (>= 1.12.8),
     jpmesh (>= 1.1.1),
     magrittr (>= 1.5),
     purrr (>= 0.2.5),

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN set -x && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libgdal-dev \
-    libudunits2-dev && \
+    libudunits2-dev \
+    zlib1g-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
@@ -15,6 +16,7 @@ RUN set -x && \
 
 RUN set -x && \
   install2.r --error \
+    data.table \
     ensurer \
     jpmesh \
     mapview \

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fgdr (development version)
 
+* Speed up `read_fgd_dem()` by using data.table for backend.
+
 # fgdr 1.0.0
 
 * `read_fdg()` and `read_fgd_dem()` always return JGD2011 (SRID: 6668).

--- a/R/commons.R
+++ b/R/commons.R
@@ -79,26 +79,25 @@ fgd_file_info <- function(file, ...) {
 }
 
 fgd_dem_file_info <- function(file, ...) {
-
   file_info <-
     fgd_file_info(file, ...)
-
   is5m <-
     file_info$xml_docs %>%
     xml2::xml_find_first("/*/*[3]/*[6]") %>% # nolint
     xml2::xml_contents() %>%
     as.character() %>%
     stringr::str_detect("5m")
-
   meshcode <-
     file_info$xml_docs %>%
     xml2::xml_find_all("/*/*[3]/*[7]") %>% # nolint
     xml2::xml_contents() %>%
     as.character()
-
+  line_startdend <-
+    which(grepl("gml:tupleList", readLines(file)))
   list(xml_docs = file_info$xml_docs,
        type = file_info$type,
        is5m = is5m,
+       skip_n = line_startdend[1],
+       limit_n = line_startdend[2] - line_startdend[1] - 1,
        meshcode = meshcode)
-
 }

--- a/R/commons.R
+++ b/R/commons.R
@@ -92,12 +92,8 @@ fgd_dem_file_info <- function(file, ...) {
     xml2::xml_find_all("/*/*[3]/*[7]") %>% # nolint
     xml2::xml_contents() %>%
     as.character()
-  line_startdend <-
-    which(grepl("gml:tupleList", readLines(file)))
   list(xml_docs = file_info$xml_docs,
        type = file_info$type,
        is5m = is5m,
-       skip_n = line_startdend[1],
-       limit_n = line_startdend[2] - line_startdend[1] - 1,
        meshcode = meshcode)
 }

--- a/R/read_fdg_dem.R
+++ b/R/read_fdg_dem.R
@@ -48,13 +48,11 @@ read_fgd_dem <- function(file, resolution = c(5, 10),
   file_info <-
     fgd_dem_file_info(file, options = xml_opts)
   df_dem <-
-    file_info$xml_docs %>%
-    xml2::xml_find_all("/*/*/*/gml:rangeSet/gml:DataBlock/gml:tupleList") %>% # nolint
-    xml2::xml_contents() %>%
-    as.character() %>%
-    readr::read_csv(col_names = c("type", "value"),
-                    col_types = c("cd"))
-
+    data.table::fread(file,
+          skip = file_info$skip_n,
+          nrows = file_info$limit_n,
+          col.names = c("type", "value"),
+          colClasses = c("character", "double"))
   df_dem$value[df_dem$type == "\u30c7\u30fc\u30bf\u306a\u3057"] <- NA_real_
   if (identical(checked, c("0", "0"))) {
     df_dem_full <-
@@ -78,7 +76,9 @@ read_fgd_dem <- function(file, resolution = c(5, 10),
       )
   }
   if (output_type == "df") {
-    df_dem_full
+    df_dem_full %>%
+      as.data.frame() %>%
+      tibble::as_tibble()
   } else if (output_type %in% c("raster", "stars")) {
     res <-
       df_dem_full %>%

--- a/R/read_fdg_dem.R
+++ b/R/read_fdg_dem.R
@@ -48,11 +48,11 @@ read_fgd_dem <- function(file, resolution = c(5, 10),
   file_info <-
     fgd_dem_file_info(file, options = xml_opts)
   df_dem <-
-    data.table::fread(file,
-          skip = file_info$skip_n,
-          nrows = file_info$limit_n,
-          col.names = c("type", "value"),
-          colClasses = c("character", "double"))
+    file_info$xml_docs %>%
+    xml2::xml_find_all("/*/*/*/gml:rangeSet/gml:DataBlock/gml:tupleList") %>% # nolint
+    xml2::xml_text() %>%
+    data.table::fread(col.names = c("type", "value"),
+                      colClasses = c("character", "double"))
   df_dem$value[df_dem$type == "\u30c7\u30fc\u30bf\u306a\u3057"] <- NA_real_
   if (identical(checked, c("0", "0"))) {
     df_dem_full <-

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -47,8 +47,8 @@ test_that("dem validation", {
     fgd_dem_file_info(system.file("extdata/FG-GML-0000-00-00-DEM5A-dummy.xml",
                                   package = "fgdr"))
   expect_is(res, "list")
-  expect_length(res, 4)
-  expect_named(res, c("xml_docs", "type", "is5m", "meshcode"))
+  expect_length(res, 6)
+  expect_named(res, c("xml_docs", "type", "is5m", "skip_n", "limit_n", "meshcode"))
   expect_equal(res$type, "DEM")
   expect_true(res$is5m)
   expect_equal(res$meshcode, "00000000")
@@ -57,8 +57,8 @@ test_that("dem validation", {
     fgd_dem_file_info(system.file("extdata/FG-GML-0000-10-dem10b-dummy.xml",
                                   package = "fgdr"))
   expect_is(res, "list")
-  expect_length(res, 4)
-  expect_named(res, c("xml_docs", "type", "is5m", "meshcode"))
+  expect_length(res, 6)
+  expect_named(res, c("xml_docs", "type", "is5m", "skip_n", "limit_n", "meshcode"))
   expect_equal(res$type, "DEM")
   expect_false(res$is5m)
   expect_equal(res$meshcode, "000000")


### PR DESCRIPTION
## Summary

`data.table::fread()` で読み込むことで高速化を図る

### Benchmark 🔩


```r
# install.packages(c("fgdr", "bench", "ggbeeswarm"))
library(fgdr)
library(bench)

res_current_5m <-
  mark(
    current = read_fgd_dem(
      "data-raw/FG-GML-5135-63-DEM5A/FG-GML-5135-63-00-DEM5A-20161001.xml",
      resolution = 5,
      return_class = "df"
    )
  )
res_current_10m <-
  mark(
    current = read_fgd_dem(
      "data-raw/FG-GML-5440-10-dem10b-20161001.xml",
      resolution = 10,
      return_class = "df"
    )
  )


pkgload::load_all()
res_dt_5m <-
  mark(
    data_table = read_fgd_dem(
      "data-raw/FG-GML-5135-63-DEM5A/FG-GML-5135-63-00-DEM5A-20161001.xml",
      resolution = 5,
      return_class = "df"
    )
  )
res_dt_10m <-
  mark(
    data_table = read_fgd_dem(
      "data-raw/FG-GML-5440-10-dem10b-20161001.xml",
      resolution = 10,
      return_class = "df"
    )
  )


rbind(
  res_current_5m,
  res_dt_5m)
#> # A tibble: 2 x 13
#> expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result             memory            time    gc            
#> <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>             <list>            <list>  <list>        
#> 1 current      36.9ms   37.9ms      25.7   11.45MB     4.68    11     2      427ms <tibble [33,750 ×… <df[,3] [2,408 ×… <bch:t… <tibble [13 ×…
#> 2 data_table   40.7ms   44.1ms      21.8    9.45MB     2.18    10     1      459ms <tibble [33,750 ×… <df[,3] [4,213 ×… <bch:t… <tibble [11 ×…>
rbind(
  res_current_10m,
  res_dt_10m)
#> # A tibble: 2 x 13
#> expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result              memory            time    gc           
#> <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>              <list>            <list>  <list>       
#> 1 current       740ms    740ms      1.35     136MB     4.05     1     3      740ms <tibble [843,750 ×… <df[,3] [70 × 3]> <bch:t… <tibble [1 ×…
#> 2 data_table    755ms    755ms      1.33      85MB     2.65     1     2      755ms <tibble [843,750 ×… <df[,3] [3,723 ×… <bch:t… <tibble [1 ×…
```

## Related issues

none